### PR TITLE
arreglar link a stack overflow en el footer

### DIFF
--- a/public/_includes/_footer.jade
+++ b/public/_includes/_footer.jade
@@ -37,7 +37,7 @@ else
 
       ul.text-body
         li <a href="http://stackoverflow.com/questions/tagged/angular2">Stack Overflow</a>
-        li <a href="http://es.stackoverflow.com/questions/tagged/angularjs-2.0">Stack Overflow</a>
+        li <a href="http://es.stackoverflow.com/questions/tagged/angularjs-2.0">Stack Overflow Español</a>
         li <a href="https://gitter.im/angular/angular">Gitter</a>
         li <a href="https://gitter.im/angular/angular">Gitter (Inglés)</a>
         li <a href="https://groups.google.com/forum/#!forum/angular"> Google Group</a>


### PR DESCRIPTION
Resulta que si dos elementos son iguales el snippet que `Shows English` no funciona bien. Entonces arregle el vinculo a Stack Overflow.
